### PR TITLE
Unreference timeout created in parseWorkflowCode

### DIFF
--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -1802,7 +1802,7 @@ export function parseWorkflowCode(code: string, codePath?: string): WorkflowBund
   setTimeout(() => {
     script = undefined;
     context = undefined;
-  }, 10000);
+  }, 10000).unref();
 
   return { code, sourceMap, filename };
 }


### PR DESCRIPTION
The `parseWorkflowCode` function creates a 10 second timeout to keep the script and context from getting garbage collected. For normal usage that timeout is not a problem, since workers are expected to run for longer than 10 seconds anyway.

However, when running unit tests these timers can keep the Node.js event loop from shutting down even after the tests have completed successfully, if the tests complete in less than 10 seconds. That's especially common when running individual tests cases rather than the entire test suite.

The fix is rather simple. We just need to "[unreference](https://nodejs.org/api/timers.html#timeoutunref)" the timer, to prevent it from keeping the event loop alive unnecessarily.

Running a single "replay history" workflow test without this fix:

```
  services
Preloading source map parsing context
2024-03-05T08:14:53.436024Z  INFO temporal_sdk_core: Registering replay worker task_queue="test"
2024-03-05T08:14:53.436079Z  INFO temporal_sdk_core::worker: Initializing worker task_queue=test namespace=default
2024-03-05T08:14:53.436139Z  INFO temporal_sdk_core::worker: Activity polling is disabled for this worker
    ✔ should fall back to use getServicesConfig while replaying a non-patched workflow (1242ms)
  1 passing (2s)
Cleaning up source map parsing context

 ——————————————————————————————————————————————————————————————————
 >  NX   Successfully ran target test for project workflows-common-services (16s)
```

Rerunning the same test case with the fix:

```
  services
Preloading source map parsing context
2024-03-05T08:15:17.629649Z  INFO temporal_sdk_core: Registering replay worker task_queue="test"
2024-03-05T08:15:17.629699Z  INFO temporal_sdk_core::worker: Initializing worker task_queue=test namespace=default
2024-03-05T08:15:17.629784Z  INFO temporal_sdk_core::worker: Activity polling is disabled for this worker
    ✔ should fall back to use getServicesConfig while replaying a non-patched workflow (1294ms)
  1 passing (2s)

 ——————————————————————————————————————————————————————————————————
 >  NX   Successfully ran target test for project workflows-common-services (13s)
```

Overall, execution time of the test running has decreased from 16s to 13s by not waiting for the 10s timeout. (There is some other cleanup work that's happening as well, which is preventing the test suite from shutting down even faster after the test has completed. But evern second in lost developer productivity counts. 😄)